### PR TITLE
Add desktop notifications for new requests in queue

### DIFF
--- a/js/labtas-4.1.js
+++ b/js/labtas-4.1.js
@@ -10,6 +10,19 @@ onOpen = function() {
     refreshQueue();
 }
 
+notify = function(m) {
+    document.title = m;
+
+    if (is_ta) {
+        var n = new Notification(m);
+        n.onclick = function () {
+            window.focus();
+            n.close();
+        };
+        setTimeout(n.close.bind(n), 5000);
+    }
+}
+
 onMessage = function(m) {
     console.log("incoming message");
     // this is a bit of a hack, but for now we'll ignore the
@@ -25,10 +38,12 @@ onMessage = function(m) {
         if (newQueue.length > queue.length && !pageActive)
         {
             newRequests += newQueue.length - queue.length;
-            if (newRequests == 1)
-                document.title = newRequests + " New Request!";
-            else
-                document.title = newRequests + " New Requests!";
+            if (newRequests == 1) {
+                notify(newRequests + " New Request!");
+            }
+            else {
+                notify(newRequests + " New Requests!");
+            }
         }
         queue = newQueue;
         refreshQueue();

--- a/templates/HelpQueue.html
+++ b/templates/HelpQueue.html
@@ -100,6 +100,9 @@
         <button class="btn btn-primary btn-xs" data-toggle="modal" data-target="#clear-modal">
             Clear the Entire Queue
         </button>
+        <button class="btn btn-primary btn-xs" onclick="Notification.requestPermission()">
+            Enable Desktop Notifications
+        </button>
     </div>
     <div class="row">
     {% endif %}


### PR DESCRIPTION
Desktop notifications for lab TAs for new requests. Currently notifies using the "X New Request!" text that's used in the document title.

Currently you have to manually grant permissions every time you load the page. There's probably a way to do this automatically.

Possible additions:
- [ ] Add notifications for students who make a request (copy modal)
- [ ] Automatically grant notification permissions after you grant it the first time
- [ ] Display info about the request itself (name, etc.) in the notification
